### PR TITLE
fixed headless description

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ This Node.js script utilizes Puppeteer for web scraping and ExcelJS for exportin
 
 ## Important Notes
 - The script assumes a specific HTML structure on the target website. Changes in the structure may require script modifications.
-- The headless browser is set to visible (`headless: false`). For production, set it to `true` for a background operation.
+- The headless browser is set to visible (`headless: false`). For production, set it to `headless: "new"` for a background operation.
 - Additional error handling may be needed based on specific use cases.
 
 Feel free to adapt the script to your requirements and consult the Puppeteer and ExcelJS documentation for further customization.


### PR DESCRIPTION
The use of puppeteer "headless" mode is changing. In some cases, if the structure of the website changes, we may not be able to access elements with `headless: true`. This will be handled with the new `headless: "new"` mode I used to solve a problem I encountered before. If you want to work in headless mode in Puppeteer projects, it would be healthier to use this mode.

![image](https://github.com/buraktanriverdi/WebScrappingToExcel/assets/84391010/e44b9e22-534f-4f7e-84b4-086187f0a0e8)
